### PR TITLE
Adaptive theme colors: respect YouTube's theme and keep surrounding UI readable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "youtube-ambientlight",
-  "version": "2.38.14",
+  "version": "2.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "youtube-ambientlight",
-      "version": "2.38.14",
+      "version": "2.39.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.21.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-ambientlight",
-  "version": "2.38.17",
+  "version": "2.39.0",
   "description": "This browser extension adds ambient light to the videos you view on YouTube",
   "repository": {
     "type": "git",
@@ -22,12 +22,12 @@
     "build:styles:options": "copyfiles -u 2 src/styles/options.css dist/styles",
     "build:styles": "run-p build:styles:content build:styles:live-chat build:styles:options",
     "build:scripts:rollup": "rollup -c",
-    "build:scripts:sourcemaps:inject": "sentry-cli sourcemaps inject ./dist/scripts --release=2.38.17",
+    "build:scripts:sourcemaps:inject": "sentry-cli sourcemaps inject ./dist/scripts --release=2.39.0",
     "build:scripts:sourcemaps:copy": "node sourcemaps-copy.js",
     "build:scripts:sourcemaps": "run-s build:scripts:sourcemaps:inject build:scripts:sourcemaps:copy",
     "build:scripts": "run-s build:scripts:rollup build:scripts:sourcemaps",
     "build": "run-s build:scripts build:styles build:manifest build:html build:images",
-    "upload-sourcemaps": "dotenvx run -f .env -f .env.local --overload -- sentry-cli sourcemaps upload ./sourcemaps --release=2.38.17"
+    "upload-sourcemaps": "dotenvx run -f .env -f .env.local --overload -- sentry-cli sourcemaps upload ./sourcemaps --release=2.39.0"
   },
   "engines": {
     "node": "22.5.1"

--- a/src/scripts/injected.js
+++ b/src/scripts/injected.js
@@ -36,14 +36,204 @@ const getElem = (() => {
   };
 })();
 
+// YouTube web component wrappers (yt-attributed-string, yt-page-header-renderer,
+// yt-lockup-view-model) stamp inline color styles from server styleRuns or from
+// ytcfg INNERTUBE_CONTEXT.client.userInterfaceTheme. Toggling html[dark] does not
+// update those inline colors, so the watch page description keeps near-black
+// light-theme text on the dark background.
+const webComponentWrapperSelector =
+  'yt-attributed-string, yt-page-header-renderer, yt-lockup-view-model';
+const ytThemeValue = (toDark) =>
+  toDark ? 'USER_INTERFACE_THEME_DARK' : 'USER_INTERFACE_THEME_LIGHT';
+
+let lastRenderedWebComponentTheme = null;
+let nativeWebComponentTheme = null;
+let webComponentObserver = null;
+
+function renderWebComponentWrapper(element, lateStamped) {
+  const { data } = element.rawProps ?? {};
+  if (
+    !element.isWebComponentWrapper ||
+    data == null ||
+    typeof element.render !== 'function'
+  )
+    return;
+
+  // Re-rendering a wrapper that contains a video element recreates the <video>,
+  // which re-initializes its GPU compositor layer over the masthead
+  if (element.querySelector('video')) return;
+
+  if (element.localName === 'yt-attributed-string' && typeof data === 'function') {
+    // fontColor styleRuns are server-set for the theme the page was requested
+    // with and ignore ytcfg; inherit the colors from the CSS cascade instead
+    element.rawProps.linkInheritColor = () => true;
+    element.rawProps.noStyleRuns = () => true;
+  } else if (lateStamped) {
+    // Late-stamped wrappers already rendered with the updated ytcfg theme
+    return;
+  } else if (
+    typeof data === 'function' &&
+    element.localName !== 'yt-page-header-renderer' &&
+    element.localName !== 'yt-lockup-view-model'
+  ) {
+    // Re-rendering other function-typed wrappers (button shapes, subscribe and
+    // notification renderers) duplicates their structure
+    return;
+  }
+
+  element.replaceChildren();
+  element.render();
+}
+
+// ytd-watch-metadata stamps the --yt-saturated-* hover palette (used by the
+// description box and the views/date line on hover) via updateHoverColor(),
+// which reads its isDark property only at initialization
+function updateSaturatedColors(element, toDark) {
+  if (!('isDark' in element) || typeof element.set !== 'function') return;
+  element.set('isDark', toDark);
+  element.updateHoverColor?.();
+}
+
+// Components such as yt-chip-cloud-renderer, ytd-watch-flexy, yt-icon and
+// yt-formatted-string each carry an independent isDarkTheme Polymer property
+// that is only set when they are stamped. Elements inside ytd-shorts always
+// receive isDarkTheme=true: the Shorts stage has a hardcoded dark background,
+// so its overlay elements need dark-mode styling in both themes
+function updateIsDarkTheme(element, toDark) {
+  if (!('isDarkTheme' in element) || typeof element.set !== 'function') return;
+  element.set('isDarkTheme', element.closest('ytd-shorts') ? true : toDark);
+}
+
+// colorData elements (like ytd-expandable-metadata-renderer) apply their
+// inline --yt-lightsource-* and --yt-basic-* variables through dataChanged(),
+// which reads isDarkTheme() only at data-init time. dataChanged() calls
+// isDarkTheme as a function while polymerController exposes it as a getter,
+// so it is temporarily shadowed with a function
+function updateColorDataElement(element, toDark) {
+  const { polymerController } = element;
+  if (!polymerController?.dataChanged) return;
+
+  // dataChanged() may asynchronously reload a video player (like a channel
+  // trailer); re-pause videos that were paused when playback resumes
+  const pausedVideos = [...element.querySelectorAll('video')].filter(
+    (video) => video.paused
+  );
+  const ownDescriptor = Object.getOwnPropertyDescriptor(
+    polymerController,
+    'isDarkTheme'
+  );
+  polymerController.isDarkTheme = () => toDark;
+  polymerController.dataChanged();
+  delete polymerController.isDarkTheme;
+  if (ownDescriptor) {
+    Object.defineProperty(polymerController, 'isDarkTheme', ownDescriptor);
+  }
+  for (const video of pausedVideos) {
+    video.addEventListener(
+      'play',
+      () => video.closest('.html5-video-player')?.pauseVideo(),
+      { once: true }
+    );
+  }
+}
+
+function onWebComponentMutations(mutations) {
+  const toDark = lastRenderedWebComponentTheme === ytThemeValue(true);
+  for (const { addedNodes } of mutations) {
+    for (const node of addedNodes) {
+      if (node.nodeType !== Node.ELEMENT_NODE) continue;
+      const elements = [node, ...node.querySelectorAll('*')];
+      // Polymer setters run before the wrapper re-renders: they can re-stamp
+      // yt-attributed-string contents, which would undo an earlier render
+      for (const element of elements) {
+        if (element.localName === 'ytd-watch-metadata') {
+          updateSaturatedColors(element, toDark);
+        }
+        updateIsDarkTheme(element, toDark);
+      }
+      for (const element of elements) {
+        if (element.matches(webComponentWrapperSelector)) {
+          renderWebComponentWrapper(element, true);
+        }
+      }
+    }
+  }
+}
+
+function updateWebComponentColors(toDark) {
+  const theme = ytThemeValue(toDark);
+  const client = window.ytcfg?.get?.('INNERTUBE_CONTEXT')?.client;
+  if (client) {
+    if (nativeWebComponentTheme === null) {
+      nativeWebComponentTheme =
+        client.userInterfaceTheme ?? ytThemeValue(false);
+    }
+    client.userInterfaceTheme = theme;
+  }
+
+  if (lastRenderedWebComponentTheme !== theme) {
+    lastRenderedWebComponentTheme = theme;
+    // Polymer setters run before the wrapper re-renders: they can re-stamp
+    // yt-attributed-string contents, which would undo an earlier render
+    for (const element of document.querySelectorAll('*')) {
+      if (element.localName === 'ytd-watch-metadata') {
+        updateSaturatedColors(element, toDark);
+      }
+      updateColorDataElement(element, toDark);
+      updateIsDarkTheme(element, toDark);
+    }
+    for (const element of document.querySelectorAll(
+      webComponentWrapperSelector
+    )) {
+      renderWebComponentWrapper(element, false);
+    }
+  }
+
+  // While the theme differs from the one the page was rendered with, wrappers
+  // stamped after this toggle (the description stamps seconds later) still carry
+  // stale server styleRun colors and must be re-rendered as they appear
+  if (theme !== nativeWebComponentTheme) {
+    if (!webComponentObserver) {
+      webComponentObserver = new MutationObserver(onWebComponentMutations);
+      webComponentObserver.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    }
+  } else if (webComponentObserver) {
+    webComponentObserver.disconnect();
+    webComponentObserver = null;
+  }
+}
+
 function updateTheme(toDark) {
+  // YouTube's CSS uses :root defaults and [dark] / [light] attribute
+  // selectors for its hashed CSS custom properties, so both attributes must
+  // be managed together. Without [light] a page that YouTube rendered in dark
+  // mode keeps its dark text colors after the dark attribute is removed
   document.documentElement.toggleAttribute('dark', toDark);
+  document.documentElement.toggleAttribute('light', !toDark);
 
   const ytdAppElem = getElem('ytd-app');
   if (ytdAppElem?.setMastheadTheme) {
     ytdAppElem.setMastheadTheme();
   }
+
+  updateWebComponentColors(toDark);
 }
+
+// After each SPA navigation YouTube stamps new elements and refreshes reused
+// ones with data from the navigation response, which carries the styleRuns of
+// YouTube's own theme. The childList observer cannot see refreshed elements,
+// so the full traversal must run again on the new page
+document.addEventListener('yt-navigate-finish', function onNavigateFinish() {
+  if (lastRenderedWebComponentTheme === null) return;
+  if (lastRenderedWebComponentTheme === nativeWebComponentTheme) return;
+
+  const toDark = document.documentElement.hasAttribute('dark');
+  lastRenderedWebComponentTheme = null;
+  updateWebComponentColors(toDark);
+});
 
 contentScript.addMessageListener(
   'update-theme',

--- a/src/scripts/libs/ambientlight.js
+++ b/src/scripts/libs/ambientlight.js
@@ -3413,6 +3413,8 @@ Video ready state: ${readyStateToString(videoElem?.readyState)}`);
       this.previousFrameTime = drawTime;
     }
 
+    this.detectHeaderBackdropColor(drawTime);
+
     if (this.enableMozillaBug1606251Workaround) {
       this.containerElem.style.transform = `translateZ(${
         this.ambientlightFrameCount % 10
@@ -3421,6 +3423,205 @@ Video ready state: ${readyStateToString(videoElem?.readyState)}`);
 
     return { hasNewFrame, detectBarSize };
   }
+
+  // While the header is transparent its icons can be displayed on top of the
+  // video (theater mode), so their contrast depends on the video frame
+  // instead of the theme. Samples the video frame region behind each header
+  // section and publishes it as --ytal-header-backdrop-region for
+  // contrast-color() based icon colors. Browsers without contrast-color()
+  // support fall back to the ytal-header-glow-dark/-light classes
+  supportsContrastColor =
+    globalThis.CSS?.supports?.('color', 'contrast-color(red)') ?? false;
+  headerBackdropDetectionTime = 0;
+  headerBackdropColors = new Map();
+  headerGlowIsDark = undefined;
+
+  detectHeaderBackdropColor = (now) => {
+    if (!this.mastheadElem) return;
+    if (now - this.headerBackdropDetectionTime < 500) return;
+    this.headerBackdropDetectionTime = now;
+
+    let samples;
+    if (this.getImageDataAllowed) {
+      try {
+        samples = this.getHeaderBackdropColors();
+      } catch {
+        samples = undefined;
+      }
+    }
+    this.updateHeaderBackdropColors(samples);
+  };
+
+  getHeaderBackdropColors() {
+    // The video is displayed on top of the glow, so it determines the
+    // backdrop wherever it is behind the header (e.g. scrolled down)
+    const videoSource = this.shouldDrawDirectlyFromVideoElem()
+      ? this.videoElem
+      : this.projectorBuffer.elem;
+    const video = {
+      rect: this.videoElem?.getBoundingClientRect(),
+      elem: videoSource,
+      width: videoSource?.videoWidth ?? videoSource?.width,
+      height: videoSource?.videoHeight ?? videoSource?.height,
+      opaque: true,
+    };
+
+    // In the immersive theater view the glow is also projected behind the
+    // header. In the other views the glow never paints behind the header
+    let glow;
+    if (
+      document.documentElement.getAttribute('data-ambientlight-immersive') !=
+      null
+    ) {
+      // The projector canvases are measured instead of their container
+      // because the spread scale transform extends beyond the container.
+      // The last canvas is the most recently drawn one
+      for (const elem of this.projectorsElem?.querySelectorAll('canvas') ??
+        []) {
+        const rect = elem.getBoundingClientRect();
+        if (!rect.width || !rect.height || !elem.width || !elem.height)
+          continue;
+        glow = {
+          rect,
+          elem,
+          width: elem.width,
+          height: elem.height,
+          opaque: false,
+        };
+      }
+    }
+
+    // The backdrop brightness can differ along the header, so each section of
+    // header icons (#start, #center and #end) contrasts with its own local
+    // backdrop color. Browsers without contrast-color() support reduce the
+    // whole header to a single dark/light fallback class instead
+    const regionElems = this.supportsContrastColor
+      ? [...this.mastheadElem.querySelectorAll('#start, #center, #end')]
+      : [];
+    if (!regionElems.length) regionElems.push(this.mastheadElem);
+
+    return regionElems.map((elem) => {
+      const rect = elem.getBoundingClientRect();
+      return {
+        elem,
+        color:
+          this.getBackdropRectColor(rect, video) ??
+          (glow ? this.getBackdropRectColor(rect, glow) : undefined),
+      };
+    });
+  }
+
+  getBackdropRectColor(rect, source) {
+    if (!rect.width || !rect.height) return undefined;
+    if (!source.rect?.width || !source.rect?.height) return undefined;
+    if (!source.width || !source.height) return undefined;
+
+    const left = Math.max(rect.left, source.rect.left);
+    const right = Math.min(rect.right, source.rect.right);
+    const top = Math.max(rect.top, source.rect.top);
+    const bottom = Math.min(rect.bottom, source.rect.bottom);
+    // Without the source behind most of this area, the page background
+    // dominates the backdrop and the theme colors apply (the CSS fallback of
+    // --ytal-header-backdrop-region)
+    const coverage =
+      right > left && bottom > top
+        ? ((right - left) * (bottom - top)) / (rect.width * rect.height)
+        : 0;
+    if (coverage < 0.5) return undefined;
+
+    if (!this.headerBackdropBuffer) {
+      const elem = new SafeOffscreenCanvas(16, 4, true);
+      this.headerBackdropBuffer = {
+        elem,
+        ctx: elem.getContext('2d', {
+          desynchronized: true,
+          willReadFrequently: true,
+        }),
+      };
+    }
+
+    // Sample the part of the source that is displayed behind this area.
+    // The color decisions are made in CSS via contrast-color()
+    const { elem, ctx } = this.headerBackdropBuffer;
+    const scaleX = source.width / source.rect.width;
+    const scaleY = source.height / source.rect.height;
+    ctx.clearRect(0, 0, elem.width, elem.height);
+    ctx.drawImage(
+      source.elem,
+      (left - source.rect.left) * scaleX,
+      (top - source.rect.top) * scaleY,
+      Math.max(1, (right - left) * scaleX),
+      Math.max(1, (bottom - top) * scaleY),
+      0,
+      0,
+      elem.width,
+      elem.height
+    );
+    const data = ctx.getImageData(0, 0, elem.width, elem.height).data;
+    // The spread fade of the glow is stored in the alpha channel and fades
+    // into the theme page background
+    const pageBackground = this.theming.isDarkTheme() ? 0 : 255;
+    const color = [0, 0, 0];
+    for (let i = 0; i < data.length; i += 4) {
+      const alpha = source.opaque ? 1 : data[i + 3] / 255;
+      color[0] += data[i] * alpha + pageBackground * (1 - alpha);
+      color[1] += data[i + 1] * alpha + pageBackground * (1 - alpha);
+      color[2] += data[i + 2] * alpha + pageBackground * (1 - alpha);
+    }
+    const pixels = data.length / 4;
+    for (let i = 0; i < 3; i++) {
+      color[i] = Math.round(color[i] / pixels);
+    }
+    return color;
+  }
+
+  updateHeaderBackdropColors = (samples) => {
+    const previousColors = this.headerBackdropColors;
+    const colors = new Map();
+    for (const { elem, color } of samples ?? []) {
+      const previousColor = previousColors.get(elem);
+      const changed =
+        !color !== !previousColor ||
+        (color &&
+          previousColor &&
+          color.some((value, i) => Math.abs(value - previousColor[i]) >= 4));
+      colors.set(elem, changed ? color : previousColor);
+      if (changed && this.supportsContrastColor) {
+        setStyleProperty(
+          elem,
+          '--ytal-header-backdrop-region',
+          color ? `rgb(${color[0]}, ${color[1]}, ${color[2]})` : ''
+        );
+      }
+      previousColors.delete(elem);
+    }
+    // Clear regions that are no longer sampled (e.g. the ambient light is
+    // hidden) so the theme colors apply again
+    for (const [elem] of previousColors) {
+      if (this.supportsContrastColor) {
+        setStyleProperty(elem, '--ytal-header-backdrop-region', '');
+      }
+    }
+    this.headerBackdropColors = colors;
+
+    if (this.supportsContrastColor || !this.mastheadElem) return;
+
+    let isDark;
+    const color = samples?.[0]?.color;
+    if (color) {
+      const luminance =
+        color[0] * 0.2126 + color[1] * 0.7152 + color[2] * 0.0722;
+      // Hysteresis prevents flickering when the luminance hovers around the
+      // threshold
+      isDark = this.headerGlowIsDark === true ? luminance < 120 : luminance < 90;
+    }
+    this.headerGlowIsDark = isDark;
+    this.mastheadElem.classList.toggle('ytal-header-glow-dark', isDark === true);
+    this.mastheadElem.classList.toggle(
+      'ytal-header-glow-light',
+      isDark === false
+    );
+  };
 
   scheduleBarSizeDetection = async () => {
     try {
@@ -3788,6 +3989,7 @@ Video ready state: ${readyStateToString(videoElem?.readyState)}`);
     this.resetVideoParentElemStyle();
     this.clear();
     this.stats.hide();
+    this.updateHeaderBackdropColors(undefined);
 
     this.updateLayoutPerformanceImprovements();
     await this.updateSizes();

--- a/src/scripts/libs/settings-config.js
+++ b/src/scripts/libs/settings-config.js
@@ -177,7 +177,7 @@ const SettingsConfig = [
     name: 'headerShadowSize',
     label: 'Shadows size',
     type: 'list',
-    default: 0,
+    default: 15,
     min: 0,
     max: 100,
     step: 0.1,

--- a/src/scripts/libs/theming.js
+++ b/src/scripts/libs/theming.js
@@ -1,5 +1,4 @@
 import {
-  getCookie,
   isEmbedPageUrl,
   isWatchPageUrl,
   on,
@@ -7,7 +6,6 @@ import {
   wrapErrorHandler,
 } from './generic';
 import { injectedScript } from './messaging/injected';
-import SentryReporter from './errors/sentry-reporter';
 import { storage } from './storage';
 
 const THEME_LIGHT = -1;
@@ -21,23 +19,47 @@ export default class Theming {
   }
 
   initListeners() {
-    // Appearance (theme) changes initiated by the YouTube menu
-    this.youtubeTheme = this.isDarkTheme() ? 1 : -1;
+    // YouTube renders its theme into the html[dark] attribute before the
+    // extension toggles anything, so the page itself is the source of the
+    // YouTube theme. The device theme media query is not a reliable source:
+    // YouTube's theme does not have to match the device theme
+    this.youtubeTheme = this.isDarkTheme() ? THEME_DARK : THEME_LIGHT;
+    // Refine with the explicit appearance choice persisted from the menu
+    this.refreshYoutubeTheme();
     on(
       document,
       'yt-action',
-      async (e) => {
+      (e) => {
         if (!this.settings.enabled) return;
         const name = e?.detail?.actionName;
         if (name === 'yt-signal-action-toggle-dark-theme-off') {
-          this.youtubeTheme = await this.prefCookieToTheme();
+          // An explicit choice that matches the device theme cannot be
+          // derived from the page, so the menu choice is persisted
+          this.youtubeThemeExplicitFromMenu = true;
+          this.youtubeTheme = THEME_LIGHT;
+          storage.set('youtube-theme-explicit', true);
           this.updateTheme();
         } else if (name === 'yt-signal-action-toggle-dark-theme-on') {
-          this.youtubeTheme = await this.prefCookieToTheme();
+          this.youtubeThemeExplicitFromMenu = true;
+          this.youtubeTheme = THEME_DARK;
+          storage.set('youtube-theme-explicit', true);
           this.updateTheme();
         } else if (name === 'yt-signal-action-toggle-dark-theme-device') {
-          this.youtubeTheme = await this.prefCookieToTheme();
-          this.updateTheme();
+          this.youtubeThemeExplicitFromMenu = false;
+          storage.set('youtube-theme-explicit', false);
+          // YouTube applies its device theme in response to this action;
+          // capture the resulting page theme instead of guessing from the
+          // device theme media query
+          this.capturingYoutubeTheme = true;
+          requestAnimationFrame(
+            wrapErrorHandler(() => {
+              this.capturingYoutubeTheme = false;
+              this.youtubeTheme = this.isDarkTheme()
+                ? THEME_DARK
+                : THEME_LIGHT;
+              this.updateTheme();
+            }, true)
+          );
         } else if (name === 'yt-forward-redux-action-to-live-chat-iframe') {
           // Let YouTube change the theme to an incorrect color in this process
           requestIdleCallback(
@@ -56,41 +78,47 @@ export default class Theming {
       true
     );
 
-    try {
-      // Firefox does not support the cookieStore
-      if (globalThis.cookieStore?.addEventListener) {
-        cookieStore.addEventListener(
-          'change',
-          wrapErrorHandler(async (e) => {
-            for (const change of e.changed) {
-              if (change.name !== 'PREF') continue;
-
-              this.youtubeTheme = await this.prefCookieToTheme(change.value);
-              this.updateTheme();
-            }
-          }, true)
-        );
-      }
-      matchMedia('(prefers-color-scheme: dark)').addEventListener(
-        'change',
-        wrapErrorHandler(async () => {
-          this.youtubeTheme = await this.prefCookieToTheme();
-          this.updateTheme();
-        }, true)
-      );
-    } catch (ex) {
-      SentryReporter.captureException(ex);
-    }
-
-    let themeCorrections = 0;
+    // Guard against YouTube overriding html[dark] / html[light] at any point
+    // after a theme toggle (e.g. when YouTube re-applies its stored account
+    // preference asynchronously after a navigation). While the extension is
+    // not controlling the theme, an attribute change is YouTube's own theme
+    // change instead (e.g. the device theme changed) and is captured as the
+    // YouTube theme. MutationObserver callbacks are microtask-queued, so
+    // after our own toggle both attributes are already correct and the
+    // conditions below short-circuit without re-invoking
     this.themeObserver = new MutationObserver(
       wrapErrorHandler(
         function themeMutation() {
-          if (!this.shouldToggleTheme()) return;
+          if (this.capturingYoutubeTheme) return;
 
-          themeCorrections++;
-          this.updateTheme();
-          if (themeCorrections === 5) this.themeObserver.disconnect();
+          const controlling =
+            this.settings.enabled &&
+            !this.ambientlight.isHidden &&
+            this.settings.theme !== THEME_DEFAULT &&
+            !this.youtubeThemeIsExplicit;
+          if (!controlling) {
+            const pageTheme = this.isDarkTheme() ? THEME_DARK : THEME_LIGHT;
+            if (this.youtubeTheme !== pageTheme) {
+              this.youtubeTheme = pageTheme;
+              if (!isEmbedPageUrl()) this.updateLiveChatTheme();
+            }
+            return;
+          }
+
+          if (this.shouldToggleTheme()) {
+            this.updateTheme();
+            return;
+          }
+
+          // The hashed CSS custom properties also depend on html[light], so
+          // re-assert it when it drifts from the applied theme
+          const toDark = this.shouldBeDarkTheme();
+          if (
+            this.isDarkTheme() === toDark &&
+            document.documentElement.hasAttribute('light') === toDark
+          ) {
+            this.updateDocumentTheme(toDark);
+          }
         }.bind(this),
         true
       )
@@ -98,7 +126,7 @@ export default class Theming {
     this.themeObserver.observe(document.documentElement, {
       attributes: true,
       attributeOldValue: true,
-      attributeFilter: ['dark'],
+      attributeFilter: ['dark', 'light'],
     });
 
     if (isEmbedPageUrl()) return;
@@ -106,22 +134,32 @@ export default class Theming {
     this.initLiveChat(); // Depends on this.youtubeTheme set in initListeners
   }
 
-  prefCookieToTheme = async (cookieValue) => {
-    if (!cookieValue) {
-      cookieValue = (await getCookie('PREF'))?.value || '';
-    }
+  // Whether the appearance has explicitly been set to Dark or Light in
+  // YouTube's own settings instead of following the device theme, observed
+  // from the YouTube menu and persisted across page loads
+  youtubeThemeExplicitFromMenu = null;
+  capturingYoutubeTheme = false;
 
-    let f6 = new URLSearchParams(cookieValue)?.get('f6') || null;
-    if (f6 != null && /^[A-Fa-f0-9]+$/.test(f6)) {
-      f6 = parseInt(f6, 16);
-    }
-    f6 = f6 || 0;
+  get youtubeThemeIsExplicit() {
+    return this.youtubeThemeExplicitFromMenu === true;
+  }
 
-    if (f6 & (1 << 165 % 31)) return THEME_DARK;
-    if (f6 & (1 << 174 % 31)) return THEME_LIGHT;
-    if (matchMedia('(prefers-color-scheme: dark)').matches) return THEME_DARK;
-    return THEME_LIGHT;
-  };
+  refreshYoutubeTheme = wrapErrorHandler(
+    async function refreshYoutubeTheme() {
+      const storedExplicit = await storage.get('youtube-theme-explicit');
+      if (
+        this.youtubeThemeExplicitFromMenu === null &&
+        typeof storedExplicit === 'boolean'
+      ) {
+        this.youtubeThemeExplicitFromMenu = storedExplicit;
+      }
+
+      // The page already provided the YouTube theme; updateTheme always runs
+      // because a toggle may already have been applied before this resolved
+      this.updateTheme();
+    }.bind(this),
+    true
+  );
 
   isDarkTheme = () => document.documentElement.getAttribute('dark') != null;
 
@@ -130,8 +168,13 @@ export default class Theming {
       enabledAndVisible === undefined
         ? !this.settings.enabled || this.ambientlight.isHidden
         : !enabledAndVisible;
+    // An appearance explicitly set to Dark or Light in YouTube's own settings
+    // is respected; the extension theme only applies while YouTube follows
+    // the device theme
     const toTheme =
-      enabled || this.settings.theme === THEME_DEFAULT
+      enabled ||
+      this.settings.theme === THEME_DEFAULT ||
+      this.youtubeThemeIsExplicit
         ? this.youtubeTheme
         : this.settings.theme;
     return toTheme === THEME_DARK;
@@ -144,6 +187,19 @@ export default class Theming {
 
   updateTheme = wrapErrorHandler(
     async function updateTheme(fromSettings = false) {
+      if (
+        fromSettings &&
+        this.youtubeThemeIsExplicit &&
+        this.settings.theme !== THEME_DEFAULT &&
+        this.settings.theme !== this.youtubeTheme
+      ) {
+        this.settings.setWarning(
+          `The appearance has been set to ${
+            this.youtubeTheme === THEME_DARK ? 'Dark' : 'Light'
+          } in YouTube's own settings and is being respected.\n\nSelect "Use device theme" in YouTube's appearance settings to let this setting control the appearance.`
+        );
+      }
+
       if (
         this.updatingTheme ||
         (!fromSettings && this.settings.theme === THEME_DEFAULT) ||

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -690,7 +690,7 @@ html[data-ambientlight-enabled] {
     #search::-webkit-input-placeholder,
     .ytSearchboxComponentInput::-webkit-input-placeholder,
     #search-clear-button yt-icon, .ytSearchboxComponentClearButton yt-icon,
-    #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon {
+    #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon, #search-icon-legacy .ytIconWrapperHost, .ytSearchboxComponentSearchButton .ytIconWrapperHost {
       transition: color .15s;
     }
     .gsst_e {
@@ -717,7 +717,13 @@ html[data-ambientlight-enabled] {
     #buttons.ytd-masthead ytd-notification-topbar-button-renderer,
     #buttons.ytd-masthead ytd-button-renderer,
     #buttons.ytd-masthead .ytd-masthead[is-icon-button] {
-      &:not(:hover) button:not(:focus) yt-icon {
+      // The ytSpec* selectors cover the new button markup, in which the
+      // button and several descendants carry their own explicit color
+      &:not(:hover) button:not(:focus) yt-icon,
+      &:not(:hover) button:not(:focus).ytSpecButtonShapeNextHost,
+      &:not(:hover) button:not(:focus) .ytIconWrapperHost,
+      &:not(:hover) button:not(:focus) .ytSpecIconBadgeShapeHost,
+      &:not(:hover) button:not(:focus) .ytSpecButtonShapeNextButtonTextContent {
         @content;
       }
     }
@@ -951,7 +957,7 @@ html[data-ambientlight-enabled] {
           }
           #search,
           #search-clear-button yt-icon, .ytSearchboxComponentClearButton yt-icon,
-          #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon {
+          #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon, #search-icon-legacy .ytIconWrapperHost, .ytSearchboxComponentSearchButton .ytIconWrapperHost {
             color: rgba(0,0,0,.4) !important;
           }
           #search,
@@ -1035,7 +1041,7 @@ html[data-ambientlight-enabled] {
           }
           #search,
           #search-clear-button yt-icon, .ytSearchboxComponentClearButton yt-icon, 
-          #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon {
+          #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon, #search-icon-legacy .ytIconWrapperHost, .ytSearchboxComponentSearchButton .ytIconWrapperHost {
             color: rgba(255,255,255,.4) !important;
           }
           #search,
@@ -1059,6 +1065,194 @@ html[data-ambientlight-enabled] {
       .ytSuggestionComponentSuggestion {
         color: rgb(241,241,241) !important;
       }
+    }
+  }
+
+  /* Header icon colors adapted to the ambient glow */
+
+  // While the header is transparent the icons are displayed on top of the
+  // ambient glow, so their contrast depends on the video frame instead of the
+  // theme. The ytal-header-glow-dark/-light classes are toggled by
+  // detectHeaderGlowBrightness based on the video frame color. Without a
+  // detected brightness (cross-origin video) the theme colors above apply
+  @mixin header-glow-icon-colors($color, $surface: null) {
+    --yt-button-color: #{$color};
+
+    #guide-icon.ytd-masthead,
+    yt-icon.ytd-topbar-logo-renderer, // old design
+    yt-icon.ytd-logo // new design
+    {
+      color: $color;
+    }
+    #country-code.ytd-topbar-logo-renderer {
+      color: color-mix(in srgb, #{$color} 60%, transparent);
+    }
+
+    @include masthead-icon {
+      color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+    }
+
+    #guide-button,
+    #back-button {
+      &:hover,
+      &:focus-within {
+        color: #{$color} !important;
+      }
+    }
+
+    ytd-topbar-menu-button-renderer,
+    ytd-notification-topbar-button-renderer,
+    ytd-button-renderer,
+    #buttons.ytd-masthead .ytd-masthead[is-icon-button] {
+      color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+      &:hover,
+      &:focus-within {
+        color: #{$color} !important;
+        // The new button markup carries its own colors, which resolve
+        // against the masthead's native dark context instead of the theme
+        button.ytSpecButtonShapeNextHost,
+        .ytIconWrapperHost,
+        .ytSpecIconBadgeShapeHost,
+        .ytSpecButtonShapeNextButtonTextContent {
+          color: #{$color} !important;
+        }
+        button.ytSpecButtonShapeNextHost {
+          background-color: color-mix(
+            in srgb,
+            #{$color} 10%,
+            transparent
+          ) !important;
+        }
+      }
+    }
+
+    #voice-search-button {
+      color: color-mix(in srgb, #{$color} 10%, transparent) !important;
+      &:not(:hover) button:not(:focus) yt-icon,
+      &:not(:hover) button:not(:focus).ytSpecButtonShapeNextHost,
+      &:not(:hover) button:not(:focus) .ytIconWrapperHost {
+        color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+      }
+      &:hover,
+      &:focus-within {
+        button {
+          color: #{$color} !important;
+        }
+      }
+    }
+
+    #{$account-btn} {
+      border-color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+      &:not(.yt-spec-button-shape-next--call-to-action) {
+        color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+      }
+    }
+
+    ytd-searchbox,
+    yt-searchbox {
+      &:not(:hover):not(:focus-within) {
+        #container.ytd-searchbox, .ytSearchboxComponentInputBox,
+        #search-icon-legacy, .ytSearchboxComponentSearchButton {
+          border-color: color-mix(in srgb, #{$color} 10%, transparent) !important;
+        }
+        #search,
+        #search-clear-button yt-icon, .ytSearchboxComponentClearButton yt-icon,
+        #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon, #search-icon-legacy .ytIconWrapperHost, .ytSearchboxComponentSearchButton .ytIconWrapperHost {
+          color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+        }
+        #search,
+        .ytSearchboxComponentInput {
+          &::-webkit-input-placeholder {
+            color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+          }
+        }
+      }
+
+      // While hovered or focused, YouTube's own styling would resolve
+      // against the masthead's native dark context instead of the theme.
+      // The backdrop color itself is the input surface, so the text and
+      // icon colors contrast with it by construction
+      @if $surface {
+        &:hover,
+        &:focus-within {
+          // Match YouTube's hover: the input field stays transparent (only a
+          // border), and only the search button gets a subtle fill. A solid
+          // surface on the whole field would look like a heavy block
+          #container.ytd-searchbox, .ytSearchboxComponentInputBox,
+          #search-icon-legacy, .ytSearchboxComponentSearchButton {
+            background-color: transparent !important;
+            border-color: color-mix(in srgb, #{$color} 10%, transparent) !important;
+          }
+          #search-icon-legacy, .ytSearchboxComponentSearchButton {
+            background-color: color-mix(in srgb, #{$color} 10%, transparent) !important;
+          }
+          #search,
+          .ytSearchboxComponentInput {
+            color: #{$color} !important;
+            &::-webkit-input-placeholder {
+              color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+            }
+          }
+          #search-clear-button yt-icon, .ytSearchboxComponentClearButton yt-icon,
+          #search-icon-legacy yt-icon, .ytSearchboxComponentSearchButton yt-icon,
+          #search-icon-legacy .ytIconWrapperHost, .ytSearchboxComponentSearchButton .ytIconWrapperHost {
+            color: #{$color} !important;
+          }
+        }
+        .ytSearchboxComponentSuggestionsContainer {
+          background-color: #{$surface} !important;
+        }
+        .ytSuggestionComponentSuggestion {
+          color: #{$color} !important;
+        }
+      }
+    }
+
+    #search-button-narrow {
+      color: color-mix(in srgb, #{$color} 60%, transparent) !important;
+      &:hover,
+      &:focus-within {
+        color: #{$color} !important;
+      }
+    }
+  }
+
+  // ytd-masthead is included to win in specificity over the
+  // ytd-masthead[dark] theme rules above
+  &:not([dark]) #masthead-container.at-top.ytal-header-glow-dark ytd-masthead,
+  &[dark] #masthead-container.at-top.ytal-header-glow-dark ytd-masthead {
+    @include header-glow-icon-colors(#fff);
+  }
+  &:not([dark]) #masthead-container.at-top.ytal-header-glow-light ytd-masthead,
+  &[dark] #masthead-container.at-top.ytal-header-glow-light ytd-masthead {
+    @include header-glow-icon-colors(#000);
+  }
+
+  // With contrast-color() support the icon colors are derived directly from
+  // the backdrop color behind the header (the page background blended with
+  // the glow, published as --ytal-header-backdrop-color by
+  // detectHeaderBackdropColor). Without a published backdrop color
+  // (cross-origin video or the ambient light is hidden) the theme page
+  // background is the fallback, so the icons follow the YouTube/extension
+  // theme. In browsers without contrast-color() support the
+  // ytal-header-glow-dark/-light classes above are used instead
+  @supports (color: contrast-color(red)) {
+    &:not([dark]) #masthead-container.at-top ytd-masthead {
+      --ytal-header-backdrop-fallback: #fff;
+    }
+    &[dark] #masthead-container.at-top ytd-masthead {
+      --ytal-header-backdrop-fallback: #000;
+    }
+    // The ytd-masthead[dark] variants win in specificity over the
+    // ytd-masthead[dark] theme rules above
+    &:not([dark]) #masthead-container.at-top ytd-masthead,
+    &:not([dark]) #masthead-container.at-top ytd-masthead[dark],
+    &[dark] #masthead-container.at-top ytd-masthead,
+    &[dark] #masthead-container.at-top ytd-masthead[dark] {
+      @include header-glow-icon-colors(
+        contrast-color(var(--ytal-header-backdrop-region, var(--ytal-header-backdrop-fallback))),
+        var(--ytal-header-backdrop-region, var(--ytal-header-backdrop-fallback))
+      );
     }
   }
 
@@ -1289,10 +1483,22 @@ html[data-ambientlight-enabled] {
 
   yt-chip-cloud-chip-renderer:not([selected]) .ytChipShapeChip {
     background: var(--ytal-background) !important;
+    color: rgb(
+      var(--ytal-text-rgb),
+      var(--ytal-text-rgb),
+      var(--ytal-text-rgb)
+    ) !important;
   }
+  // YouTube no longer defines --yt-spec-inverted-background and
+  // --yt-spec-text-primary-inverse; without fallbacks the selected chip
+  // becomes transparent with inherited text
   yt-chip-cloud-chip-renderer[selected] .ytChipShapeChip {
-    background: var(--yt-spec-inverted-background) !important;
-    color: var(--yt-spec-text-primary-inverse) !important;
+    background: var(--yt-spec-inverted-background, #0f0f0f) !important;
+    color: var(--yt-spec-text-primary-inverse, #fff) !important;
+  }
+  &[dark] yt-chip-cloud-chip-renderer[selected] .ytChipShapeChip {
+    background: var(--yt-spec-inverted-background, #f1f1f1) !important;
+    color: var(--yt-spec-text-primary-inverse, #0f0f0f) !important;
   }
   
   ytd-watch-metadata {


### PR DESCRIPTION
## Summary

When the **Appearance (theme)** setting forces Light (or Dark) and YouTube served the page in the opposite theme, the surrounding chrome was left in the original theme — the video title, description, comments and related content kept near‑white text on the light page (and similar mismatches the other way). This PR makes the forced theme actually re‑style YouTube's components, derives the masthead/header colors from what is actually behind them, and stops the extension from overriding an **explicit** YouTube theme choice.

Everything was verified live in the browser (Chrome DevTools) across YouTube‑dark/light × extension‑dark/light, on page load, on SPA navigation, and on theme changes.

### Before / After

Extension theme = **Light**, device (YouTube) theme = **Dark**:

| Before (`develop`) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/avi12/youtube-ambilight/pr-assets/before-light-page.png) | ![after](https://raw.githubusercontent.com/avi12/youtube-ambilight/pr-assets/after-light-page.png) |

In *Before*, `html[dark]` is removed but `html[light]` is never set and the Polymer components keep their dark‑theme inline colors, so the title/description render `rgb(241,241,241)` on white. *After* renders them `rgb(15,15,15)`.

## Highlights

- **Theme is read from the page, not the cookie.** The YouTube theme now comes from the `html[dark]` attribute that YouTube renders itself, instead of parsing the `PREF` cookie (which doesn't carry the appearance preference of signed‑in users) or `prefers-color-scheme` (which can differ from the YouTube theme).
- **Explicit YouTube choices are respected.** If the user set Dark/Light in YouTube's own settings, the extension defers to it; the extension theme only applies while YouTube follows the device theme. The choice is observed from the appearance menu and persisted across loads, with a warning explaining how to hand control back.
- **Forced theme re‑styles YouTube's web components.** Syncs the `ytcfg` theme and re‑renders `yt-attributed-string` / `yt-page-header-renderer` / `yt-lockup-view-model`, propagates `isDarkTheme` and the saturated hover palette to the Polymer elements that cache them, and re‑runs `dataChanged()` on colorData elements. A `MutationObserver` covers elements stamped after the toggle and a `yt-navigate-finish` handler re‑runs the pass on SPA navigations. Both `html[dark]` and `html[light]` are now managed together.
- **Header icons adapt to their backdrop.** While the header is transparent its icons/text sit over the video frame and ambient glow, so a fixed color can become unreadable. The backdrop color behind each header region (`#start`, `#center`, `#end`) is sampled and exposed as a CSS variable; icon, text and search‑box colors are derived with `contrast-color()` so they stay legible on any backdrop. Browsers without `contrast-color()` support fall back to a per‑luminance dark/light class.
- **Surrounding‑chrome fixes:** chip‑cloud chips get fallback colors now that YouTube dropped the CSS variables they relied on, and the masthead icon rules were extended to YouTube's new button markup (Create / search / notifications recolor correctly).
- **Page header shadows are enabled by default** (size `15`, matching the page‑content shadows) so header text/icons stay readable over bright frames.

## Commits

1. Bump version to 2.39.0
2. Detect the YouTube theme from the page and respect explicit choices
3. Re-render web components so text follows the toggled theme
4. Enable page header shadows by default
5. Adapt header icon colors to the backdrop behind the masthead

## Notes

- No new permissions; no `minimum_chrome_version` bump — the `contrast-color()` path is wrapped in `@supports` with a fallback, so older browsers keep working.
- The screenshots are hosted on a separate `pr-assets` branch in the fork and are not part of this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
